### PR TITLE
OpenAPI file download inclusion

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ This is a work in progress and right now creates just a blank `MainVerticle` cla
 - Integrates OpenAPI Generator via Maven Plugin
 - Generates JPA Entity classes from the OpenAPI contract
 - Generates jOOQ Query DSL classes from the Hibernate/JPA entities
-- Creates a *stub* Vert.x Main Verticle
+- Creates a **stub** Vert.x Main Verticle
 - Allows you to choose between jOOQ and Hibernate Reactive
 - Allows you to choose between basic Vert.x style callbacks, RxJava2, and Mutiny for async APIs
 

--- a/src/main/resources/META-INF/archetype-post-generate.groovy
+++ b/src/main/resources/META-INF/archetype-post-generate.groovy
@@ -10,7 +10,6 @@ Properties properties = request.properties
 
 String dbLibrary = properties.getOrDefault("openapi_app_database_library", "jooq")
 
-
 String operatingSystem = System.getProperty("os.name").toLowerCase(Locale.ENGLISH)
 
 if (!operatingSystem.contains("windows")) {
@@ -20,6 +19,13 @@ if (!operatingSystem.contains("windows")) {
   Files.setPosixFilePermissions(mvnWrapper, PosixFilePermissions.fromString("rwxrwxrwx"))
 
 }
+
+// Download/Copy OpenAPI file into project
+Path openApiPath = Paths.get(request.outputDirectory, request.artifactId, "modules", "api", "src", "main", "resources")
+openApiPath.toFile().mkdirs()
+Path openApiFile = Paths.get(openApiPath.toAbsolutePath().toString(), "openapi.yml")
+URL openApiSource = new URL(properties.getProperty('openapi_app_contract_uri'))
+openApiFile.toFile() << openApiSource.openStream()
 
 if (dbLibrary.contentEquals("hibernate")) {
   Path dataAccess = Paths.get(projectPath.toAbsolutePath().toString(), "modules", "data-access")

--- a/src/main/resources/archetype-resources/modules/models/pom.xml
+++ b/src/main/resources/archetype-resources/modules/models/pom.xml
@@ -131,7 +131,7 @@
                             <generateSupportingFiles>false</generateSupportingFiles>
                             <output>./</output>
                             <skipOverwrite>false</skipOverwrite>
-                            <inputSpec>${openapi_app_contract_uri}</inputSpec>
+                            <inputSpec>${project.basedir}/../api/src/main/resources/openapi.yml</inputSpec>
                             <configOptions>
                                 <dateLibrary>java8-localdatetime</dateLibrary>
                                 <modelPackage>${package}.models</modelPackage>


### PR DESCRIPTION
Modify the post-generate Groovy script to copy the given OpenAPI YAML File to the API module's `src/main/resources` directory. Also, modifies the `models` POM to reference the API Contract from that location as well.